### PR TITLE
Add configs for hardhat forking

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,6 +1,21 @@
 require("@nomiclabs/hardhat-waffle");
 require("@nomiclabs/hardhat-ethers");
 
+
+// When using the hardhat network, you may choose to fork Fuji or Avalanche Mainnet
+// This will allow you to debug contracts using the hardhat network while keeping the current network state
+// To enable forking, turn one of these booleans on, and then run your tasks/scripts using ``--network hardhat``
+// For more information go to the hardhat guide
+// https://hardhat.org/hardhat-network/
+// https://hardhat.org/guides/mainnet-forking.html
+const FORK_FUJI = false;
+const FORK_MAINNET = false;
+const forkingData = FORK_FUJI ? {
+  url: 'https://api.avax-test.network/ext/bc/C/rpc',
+} : FORK_MAINNET ? {
+  url: 'https://api.avax.network/ext/bc/C/rpc'
+} : undefined
+
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://hardhat.org/guides/create-task.html
 task("accounts", "Prints the list of accounts", async () => {
@@ -46,7 +61,8 @@ module.exports = {
   networks: {
     hardhat: {
       gasPrice: 225000000000,
-      chainId: 43112,
+      chainId: !forkingData ? 43112 : undefined, //Only specify a chainId if we are not forking
+      forking: forkingData
     },
     avash: {
       url: 'http://localhost:9650/ext/bc/C/rpc',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ethereum-waffle": "^3.2.1",
     "ethereumjs-tx": "^2.1.2",
     "ethers": "^5.0.24",
-    "hardhat": "^2.3.0",
+    "hardhat": "^2.2.0",
     "web3": "^1.3.1"
   },
   "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ethereum-waffle": "^3.2.1",
     "ethereumjs-tx": "^2.1.2",
     "ethers": "^5.0.24",
-    "hardhat": "^2.0.6",
+    "hardhat": "^2.3.0",
     "web3": "^1.3.1"
   },
   "version": "1.0.0",


### PR DESCRIPTION
This PR adds configuration for the hardhat forking feature. As of Hardhat 2.2.0, forking both Fuji and Mainnet C-Chain are fully supported, and using the public API endpoints seem to work well.  
This PR also bumps the minimum version requirement for Hardhat to be 2.2.0, since older version of Hardhat do not support forking Fuji or Mainnet C-Chain