### PR TITLE
Update hardhat version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ethereum-waffle": "^3.2.1",
     "ethereumjs-tx": "^2.1.2",
     "ethers": "^5.0.24",
-    "hardhat": "2.3.0",
+    "hardhat": "2.4.3",
     "ts-node": "^9.1.1",
     "web3": "^1.3.1"
   },


### PR DESCRIPTION
You are using hardhat 2.3.0 and this version has a issue called "Cannot read property 'gteHardfork' of undefined".

This issue fixed by Hardhat version 2.4.3: https://github.com/nomiclabs/hardhat/releases/tag/hardhat-core-v2.4.3