### PR TITLE
Update README.md wrong file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ yarn
 
 ## Write Contracts
 
-Edit the `Coin.sol` contract in `contracts/`. `Coin.sol` is an [Open Zeppelin](https://openzeppelin.com) [ERC20](https://eips.ethereum.org/EIPS/eip-20) contract. ERC20 is a popular smart contract interface. You can also add your own contracts.
+Edit the `ExampleERC20.sol` contract in `contracts/`. `ExampleERC20.sol` is an [Open Zeppelin](https://openzeppelin.com) [ERC20](https://eips.ethereum.org/EIPS/eip-20) contract. ERC20 is a popular smart contract interface. You can also add your own contracts.
 
 ## Hardhat Config
 


### PR DESCRIPTION
The guide still says to edit `Coin.sol`, 
![image](https://user-images.githubusercontent.com/42378648/145930449-b57d09a9-ea08-42e4-bde0-ae5547674b41.png)


but there is no such file. In [this commit](https://github.com/ava-labs/avalanche-smart-contract-quickstart/commit/fb8d3021bd7cb0edbf9363325a073eff7a568413#diff-b094db7ce2f99cbcbde7ec178a6754bac666e2192f076807acbd70d49ddd0559), @cgcardona renamed `Coin.sol` to `ExampleERC20.sol`.